### PR TITLE
add project revision shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ Add this plugin to the `plugins` section at server config
 plugins:
     - nci-shields
 ```
-after that you can get status shield at `http://localhost:3000/shields/:projectName.svg` for project or
-`http://localhost:3000/shields/builds/:id.svg` for build
+after that you can get status shields:
+
+* `http://localhost:3000/shields/:projectName.svg` for project
+* `http://localhost:3000/shields/builds/:id.svg` for build
+* `http://localhost:3000/shields/:projectName/revs/:rev.svg` for project revision
+(any scm revision, tag, branch that was selected as target for the build)
 
 ## Legal
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,4 +59,31 @@ exports.register = function(app) {
 			}
 		});
 	});
+
+	app.express.get('/shields/:projectName/revs/:rev.svg', function(req, res, next) {
+		var projectName = req.params.projectName,
+			rev = req.params.rev;
+
+		if (!app.projects.get(projectName)) {
+			return res.sendStatus(404);
+		}
+
+		app.builds.getRecent({
+			limit: 1,
+			projectName: projectName,
+			filter: function(build) {
+				return (
+					build.project &&
+					build.project.scm &&
+					build.project.scm.rev === rev
+				);
+			}
+		}, function(err, builds) {
+			if (err) {
+				logger.error(err.stack || err);
+			}
+
+			sendSvg(res, !_(builds).isEmpty() && _(builds).first().status);
+		});
+	});
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/fleg/nci-shields#readme",
   "peerDependencies": {
-    "nci": ">=1.0.1 <1.1.0",
+    "nci": ">=1.0.13 <1.1.0",
     "nci-express": ">=2.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Pr contains project revision shield (any scm revision, tag, branch that was selected as target for the build) implementation with tests and readme update, It also requires new nci 1.0.13 which provides ```filter``` option for getRecent method (builds collection). 